### PR TITLE
Added DRLParserWrapper to store errors using DRLErrorListener

### DIFF
--- a/drools-parser/pom.xml
+++ b/drools-parser/pom.xml
@@ -47,6 +47,12 @@
       <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${version.ch.qos.logback}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/drools-parser/src/main/java/org/drools/parser/DRLErrorListener.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLErrorListener.java
@@ -1,0 +1,28 @@
+package org.drools.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+
+public class DRLErrorListener extends BaseErrorListener {
+
+    private final List<DRLParserError> errors = new ArrayList<>();
+
+    public List<DRLParserError> getErrors() {
+        return errors;
+    }
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer,
+                            Object offendingSymbol,
+                            int line,
+                            int charPositionInLine,
+                            String msg,
+                            RecognitionException e) {
+
+        errors.add(new DRLParserError(line, charPositionInLine, msg));
+    }
+}

--- a/drools-parser/src/main/java/org/drools/parser/DRLParserError.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLParserError.java
@@ -1,0 +1,54 @@
+package org.drools.parser;
+
+public class DRLParserError {
+
+    private int lineNumber;
+    private int column;
+    private String message;
+
+    private Exception exception;
+
+    public DRLParserError(int lineNumber, int column, String message) {
+        this.lineNumber = lineNumber;
+        this.column = column;
+        this.message = message;
+    }
+
+    public DRLParserError(Exception exception) {
+        this.exception = exception;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    public void setColumn(int column) {
+        this.column = column;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return "DRLParserError{" +
+                "lineNumber=" + lineNumber +
+                ", column=" + column +
+                ", message='" + message + '\'' +
+                ", exception=" + exception +
+                '}';
+    }
+}

--- a/drools-parser/src/main/java/org/drools/parser/DRLParserWrapper.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLParserWrapper.java
@@ -1,0 +1,45 @@
+package org.drools.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DRLParserWrapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DRLParserWrapper.class);
+
+    private final List<DRLParserError> errors = new ArrayList<>();
+
+    public DRLParserWrapper() {
+    }
+
+    public PackageDescr parse(String drl) {
+        DRLParser drlParser = DRLParserHelper.createDrlParser(drl);
+        DRLErrorListener errorListener = new DRLErrorListener();
+        drlParser.addErrorListener(errorListener);
+
+        ParseTree parseTree = drlParser.compilationUnit();
+
+        errors.addAll(errorListener.getErrors());
+
+        try {
+            return DRLParserHelper.parseTree2PackageDescr(parseTree);
+        } catch (Exception e) {
+            LOGGER.error("Exception while creating PackageDescr", e);
+            errors.add(new DRLParserError(e));
+            return null;
+        }
+    }
+
+    public List<DRLParserError> getErrors() {
+        return errors;
+    }
+
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+}

--- a/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
+++ b/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
@@ -1,0 +1,51 @@
+package org.drools.parser;
+
+import junit.framework.TestCase;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/*
+ * This test class is being ported from org.drools.mvel.compiler.lang.RuleParserTest
+ */
+public class MiscDRLParserTest extends TestCase {
+
+    private DRLParserWrapper parser;
+
+    @Before
+    protected void setUp() throws Exception {
+        super.setUp();
+        parser = new DRLParserWrapper();
+    }
+
+    @After
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    public void testPackage() throws Exception {
+        final String source = "package foo.bar.baz";
+        final PackageDescr pkg = parser.parse(source);
+        assertEquals("foo.bar.baz", pkg.getName());
+    }
+
+    @Test
+    public void testPackageWithErrorNode() throws Exception {
+        final String source = "package 12 foo.bar.baz";
+        final PackageDescr pkg = parser.parse(source);
+        assertTrue(parser.hasErrors());
+        // getText() combines an ErrorNode "12" so the result is different from DRL6Parser.
+        assertEquals("12foo.bar.baz", pkg.getName());
+    }
+
+    @Test
+    public void testPackageWithAllErrorNode() throws Exception {
+        final String source = "package 12 12312 231";
+        final PackageDescr pkg = parser.parse(source);
+        assertTrue(parser.hasErrors());
+        // NPE inside DRLVisitorImpl.visitIdentifier(). So pkg is null. Different from DRL6Parser.
+        assertNull(pkg);
+    }
+}

--- a/drools-parser/src/test/resources/logback-test.xml
+++ b/drools-parser/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="warn"/>
+  <logger name="org.drools" level="warn"/>
+
+  <root level="warn">
+    <appender-ref ref="consoleAppender" />
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <version.org.eclipse.lsp4j>0.12.0</version.org.eclipse.lsp4j>
     <version.antlr4-c3>1.1</version.antlr4-c3>
     <version.junit>4.13.2</version.junit>
+    <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
   </properties>
 
   <modules>


### PR DESCRIPTION
### Added `DRLParserWrapper` to store errors using `DRLErrorListener`
By default, `DRLParser` prints errors to syserr. In order to validate the errors in test cases (and also to bring the errors for future engine integration), I think we eventually need a wrapper like `DRLParserWrapper`. Do you think this Is a right direction? There could be a better class name though.

I suppose `DRLParserHelper` in drools-lsp is a static util for the generated `DRLParser`. We may be able to combine `DRLParserWrapper` and `DRLParserHelper` into one class but I keep them separated for now.

Btw, In the current Drools implementation, `org.drools.drl.parser.lang.AbstractDRLParser` stores errors in `ParserHelper`.

### Added `MiscDRLParserTest` which is being ported from `RuleParserTest` to enhance test coverage.

https://github.com/kiegroup/drools/blob/main/drools-test-coverage/test-compiler-integration/src/test/java/org/drools/mvel/compiler/lang/RuleParserTest.java

RuleParserTest validates Descr classes as DRL parse results so I think it's good to port the tests to increase the test coverage. At the moment, I just ported a few test methods (and no need to fix antlr4 grammar yet). I will port more tests and will likely fix antlr4 grammar and DRLVisitorImpl when needed. Do you think it's the right direction?
