### PR TITLE
Enhance test/grammar coverage. function import, global, exists, not

### DIFF
--- a/drools-parser/src/main/antlr4/org/drools/parser/DRLLexer.g4
+++ b/drools-parser/src/main/antlr4/org/drools/parser/DRLLexer.g4
@@ -32,8 +32,10 @@ WHEN : 'when';
 THEN : 'then';
 END : 'end';
 
+EXISTS : 'exists';
 NOT : 'not';
 IN : 'in';
+FROM : 'from';
 
 SALIENCE : 'salience';
 ENABLED : 'enabled';

--- a/drools-parser/src/main/java/org/drools/parser/DRLParserHelper.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLParserHelper.java
@@ -3,8 +3,11 @@ package org.drools.parser;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
 import org.drools.drl.ast.descr.PackageDescr;
 
 public class DRLParserHelper {
@@ -45,5 +48,28 @@ public class DRLParserHelper {
                 return token.getTokenIndex();
         }
         return null;
+    }
+
+    /**
+     * RuleContext.getText() connects all nodes including ErrorNode. This method appends texts only from valid nodes
+     */
+    public static String getTextWithoutErrorNode(ParseTree tree) {
+        if (tree.getChildCount() == 0) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < tree.getChildCount(); i++) {
+            ParseTree child = tree.getChild(i);
+            if (!(child instanceof ErrorNode)) {
+                if (child instanceof TerminalNode) {
+                    builder.append(child.getText());
+                } else {
+                    builder.append(getTextWithoutErrorNode(child));
+                }
+            }
+        }
+
+        return builder.toString();
     }
 }

--- a/drools-parser/src/main/java/org/drools/parser/DRLParserWrapper.java
+++ b/drools-parser/src/main/java/org/drools/parser/DRLParserWrapper.java
@@ -2,6 +2,7 @@ package org.drools.parser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.drools.drl.ast.descr.PackageDescr;
@@ -37,6 +38,10 @@ public class DRLParserWrapper {
 
     public List<DRLParserError> getErrors() {
         return errors;
+    }
+
+    public List<String> getErrorMessages() {
+        return errors.stream().map(DRLParserError::getMessage).collect(Collectors.toList());
     }
 
     public boolean hasErrors() {

--- a/drools-parser/src/main/java/org/drools/parser/StringUtils.java
+++ b/drools-parser/src/main/java/org/drools/parser/StringUtils.java
@@ -1,0 +1,20 @@
+package org.drools.parser;
+
+/**
+ * will be merged in drools-util
+ */
+public class StringUtils {
+
+    private StringUtils() {
+    }
+
+    public static String safeStripStringDelimiters(String value) {
+        if (value != null) {
+            value = value.trim();
+            if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+                value = value.substring(1, value.length() - 1);
+            }
+        }
+        return value;
+    }
+}

--- a/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
+++ b/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
@@ -1,7 +1,23 @@
 package org.drools.parser;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import junit.framework.TestCase;
+import org.drools.drl.ast.descr.FromDescr;
+import org.drools.drl.ast.descr.FunctionImportDescr;
+import org.drools.drl.ast.descr.GlobalDescr;
+import org.drools.drl.ast.descr.ImportDescr;
+import org.drools.drl.ast.descr.NotDescr;
 import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.ast.descr.PatternDescr;
+import org.drools.drl.ast.descr.RuleDescr;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +40,19 @@ public class MiscDRLParserTest extends TestCase {
         super.tearDown();
     }
 
+    private PackageDescr parseResource(final String filename) throws Exception {
+        Path path = Paths.get(getClass().getResource(filename).toURI());
+        final StringBuilder sb = new StringBuilder();
+        try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            for (String line; (line = br.readLine()) != null; ) {
+                sb.append(line + "\n");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return parser.parse(sb.toString());
+    }
+
     @Test
     public void testPackage() throws Exception {
         final String source = "package foo.bar.baz";
@@ -36,8 +65,7 @@ public class MiscDRLParserTest extends TestCase {
         final String source = "package 12 foo.bar.baz";
         final PackageDescr pkg = parser.parse(source);
         assertTrue(parser.hasErrors());
-        // getText() combines an ErrorNode "12" so the result is different from DRL6Parser.
-        assertEquals("12foo.bar.baz", pkg.getName());
+        assertEquals("foo.bar.baz", pkg.getName());
     }
 
     @Test
@@ -45,7 +73,208 @@ public class MiscDRLParserTest extends TestCase {
         final String source = "package 12 12312 231";
         final PackageDescr pkg = parser.parse(source);
         assertTrue(parser.hasErrors());
-        // NPE inside DRLVisitorImpl.visitIdentifier(). So pkg is null. Different from DRL6Parser.
-        assertNull(pkg);
+        assertEquals("", pkg.getName());
+    }
+
+    @Test
+    public void testCompilationUnit() throws Exception {
+        final String source = "package foo; import com.foo.Bar; import com.foo.Baz;";
+        PackageDescr pkg = parser.parse(source);
+        assertFalse(parser.getErrors().toString(),
+                    parser.hasErrors());
+        assertEquals("foo",
+                     pkg.getName());
+        assertEquals(2,
+                     pkg.getImports().size());
+        ImportDescr impdescr = pkg.getImports().get(0);
+        assertEquals("com.foo.Bar",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length(),
+                     impdescr.getEndCharacter());
+
+        impdescr = pkg.getImports().get(1);
+        assertEquals("com.foo.Baz",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length(),
+                     impdescr.getEndCharacter());
+    }
+
+    @Test
+    public void testFunctionImport() throws Exception {
+        final String source = "package foo\n" +
+                "import function java.lang.Math.max\n" +
+                "import function java.lang.Math.min;\n" +
+                "import foo.bar.*\n" +
+                "import baz.Baz";
+        PackageDescr pkg = parser.parse(source);
+        assertFalse(parser.getErrors().toString(),
+                    parser.hasErrors());
+        assertEquals("foo",
+                     pkg.getName());
+        assertEquals(2,
+                     pkg.getImports().size());
+        ImportDescr impdescr = pkg.getImports().get(0);
+        assertEquals("foo.bar.*",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+
+        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1,
+                     impdescr.getEndCharacter());
+
+        impdescr = pkg.getImports().get(1);
+        assertEquals("baz.Baz",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1,
+                     impdescr.getEndCharacter());
+
+        assertEquals(2,
+                     pkg.getFunctionImports().size());
+        impdescr = pkg.getFunctionImports().get(0);
+        assertEquals("java.lang.Math.max",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import function " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+        assertEquals(source.indexOf("import function " + impdescr.getTarget()) + ("import function " + impdescr.getTarget()).length() - 1,
+                     impdescr.getEndCharacter());
+
+        impdescr = pkg.getFunctionImports().get(1);
+        assertEquals("java.lang.Math.min",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import function " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+        assertEquals(source.indexOf("import function " + impdescr.getTarget()) + ("import function " + impdescr.getTarget()).length(),
+                     impdescr.getEndCharacter());
+    }
+
+    @Test
+    public void testGlobalWithComplexType() throws Exception {
+        final String source = "package foo.bar.baz\n" +
+                "import com.foo.Bar\n" +
+                "global java.util.List<java.util.Map<String,Integer>> aList;\n" +
+                "global Integer aNumber";
+        PackageDescr pkg = parser.parse(source);
+        assertFalse(parser.getErrors().toString(),
+                    parser.hasErrors());
+        assertEquals("foo.bar.baz",
+                     pkg.getName());
+        assertEquals(1,
+                     pkg.getImports().size());
+
+        ImportDescr impdescr = pkg.getImports().get(0);
+        assertEquals("com.foo.Bar",
+                     impdescr.getTarget());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()),
+                     impdescr.getStartCharacter());
+        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1,
+                     impdescr.getEndCharacter());
+
+        assertEquals(2,
+                     pkg.getGlobals().size());
+
+        GlobalDescr global = pkg.getGlobals().get(0);
+        assertEquals("java.util.List<java.util.Map<String,Integer>>",
+                     global.getType());
+        assertEquals("aList",
+                     global.getIdentifier());
+        assertEquals(source.indexOf("global " + global.getType()),
+                     global.getStartCharacter());
+        assertEquals(source.indexOf("global " + global.getType() + " " + global.getIdentifier()) +
+                             ("global " + global.getType() + " " + global.getIdentifier()).length(),
+                     global.getEndCharacter());
+
+        global = pkg.getGlobals().get(1);
+        assertEquals("Integer",
+                     global.getType());
+        assertEquals("aNumber",
+                     global.getIdentifier());
+        assertEquals(source.indexOf("global " + global.getType()),
+                     global.getStartCharacter());
+        assertEquals(source.indexOf("global " + global.getType() + " " + global.getIdentifier()) +
+                             ("global " + global.getType() + " " + global.getIdentifier()).length() - 1,
+                     global.getEndCharacter());
+    }
+
+    @Test
+    public void testGlobalWithOrWithoutSemi() throws Exception {
+        PackageDescr pack = parseResource("globals.drl");
+
+        assertEquals(1,
+                     pack.getRules().size());
+
+        final RuleDescr rule = (RuleDescr) pack.getRules().get(0);
+        assertEquals(1,
+                     rule.getLhs().getDescrs().size());
+
+        assertEquals(1,
+                     pack.getImports().size());
+        assertEquals(2,
+                     pack.getGlobals().size());
+
+        final GlobalDescr foo = (GlobalDescr) pack.getGlobals().get(0);
+        assertEquals("java.lang.String",
+                     foo.getType());
+        assertEquals("foo",
+                     foo.getIdentifier());
+        final GlobalDescr bar = (GlobalDescr) pack.getGlobals().get(1);
+        assertEquals("java.lang.Integer",
+                     bar.getType());
+        assertEquals("bar",
+                     bar.getIdentifier());
+    }
+
+    @Test
+    public void testFunctionImportWithNotExist() throws Exception {
+        PackageDescr pkg = (PackageDescr) parseResource("test_FunctionImport.drl");
+
+        assertEquals(2,
+                     pkg.getFunctionImports().size());
+
+        assertEquals("abd.def.x",
+                     ((FunctionImportDescr) pkg.getFunctionImports().get(0)).getTarget());
+        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getStartCharacter() == -1);
+        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getEndCharacter() == -1);
+        assertEquals("qed.wah.*",
+                     ((FunctionImportDescr) pkg.getFunctionImports().get(1)).getTarget());
+        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getStartCharacter() == -1);
+        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getEndCharacter() == -1);
+    }
+
+    @Test
+    public void testFromComplexAcessor() throws Exception {
+        String source = "rule \"Invalid customer id\" ruleflow-group \"validate\" lock-on-active true \n" +
+                " when \n" +
+                "     o: Order( ) \n" +
+                "     not( Customer( ) from customerService.getCustomer(o.getCustomerId()) ) \n" +
+                " then \n" +
+                "     System.err.println(\"Invalid customer id found!\"); " +
+                "\n" +
+                "     o.addError(\"Invalid customer id\"); \n" +
+                "end \n";
+        PackageDescr pkg = parser.parse(source);
+
+        assertFalse(parser.getErrorMessages().toString(),
+                    parser.hasErrors());
+
+        RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
+        assertEquals("Invalid customer id",
+                     rule.getName());
+
+        assertEquals(2,
+                     rule.getLhs().getDescrs().size());
+
+        NotDescr not = (NotDescr) rule.getLhs().getDescrs().get(1);
+        PatternDescr customer = (PatternDescr) not.getDescrs().get(0);
+
+        assertEquals("Customer",
+                     customer.getObjectType());
+        assertEquals("customerService.getCustomer(o.getCustomerId())",
+                     ((FromDescr) customer.getSource()).getDataSource().getText());
     }
 }

--- a/drools-parser/src/test/resources/org/drools/parser/globals.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/globals.drl
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.drools.compiler.test;
+
+import org.drools.compiler.Cheese;
+
+global java.lang.String foo
+global java.lang.Integer bar;
+
+rule baz
+    when
+        Cheese( )
+    then
+
+end

--- a/drools-parser/src/test/resources/org/drools/parser/test_FunctionImport.drl
+++ b/drools-parser/src/test/resources/org/drools/parser/test_FunctionImport.drl
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package HR1
+
+import function abd.def.x
+import function qed.wah.*
+
+rule simple_rule 
+  when
+      not ( Cheese(type == "stilton") )
+      exists ( Foo() )
+  then
+    funky();
+end


### PR DESCRIPTION
I keep porting test methods from `RuleParserTest` to `MiscDRLParserTest`. As you see, fixes in the grammar and Visitor are still partial, just to satisfy test cases. But going through the process, the grammar and Visitor will be strengthened. That's the plan.

Feel free to provide comments, feedback and suggestions.