### PR TITLE
OpenRewrite applied for junit5 and assertj

### DIFF
--- a/drools-completion/pom.xml
+++ b/drools-completion/pom.xml
@@ -26,18 +26,29 @@
       <artifactId>antlr4-c3</artifactId>
       <version>${version.antlr4-c3}</version>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.eclipse.lsp4j</groupId>
       <artifactId>org.eclipse.lsp4j</artifactId>
       <version>0.12.0</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.org.assertj}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.org.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.org.junit}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -14,16 +14,16 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class DRLCompletionHelperTest {
+class DRLCompletionHelperTest {
 
-    @Ignore
+    @Disabled("TBD")
     @Test
-    public void testGetCompletionItems() {
+    void testGetCompletionItems() {
         // TODO
         String text = "rule MyRule when Dog(name == \"Bart\") then end";
         CompletionParams completionParams = new CompletionParams();
@@ -36,11 +36,11 @@ public class DRLCompletionHelperTest {
 
         List<CompletionItem> result = DRLCompletionHelper.getCompletionItems(text, caretPosition, getLanguageClient());
         CompletionItem completionItem = result.get(0);
-        assertEquals("suggestion", completionItem.getInsertText());
+        assertThat(completionItem.getInsertText()).isEqualTo("suggestion");
     }
 
     @Test
-    public void testTestGetCompletionItems() {
+    void testTestGetCompletionItems() {
         // TODO
     }
 

--- a/drools-lsp-server/pom.xml
+++ b/drools-lsp-server/pom.xml
@@ -27,14 +27,26 @@
       <artifactId>org.eclipse.lsp4j</artifactId>
       <version>${version.org.eclipse.lsp4j}</version>
     </dependency>
-
-    <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.org.assertj}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.org.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.org.junit}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Tests -->
   </dependencies>
 
   <build>

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspDocumentServiceTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/DroolsLspDocumentServiceTest.java
@@ -1,35 +1,20 @@
-package org.drools.lsp.server;/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package org.drools.lsp.server;
+
+import java.util.List;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.drools.lsp.server.TestHelperMethods.getDroolsLspDocumentService;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-public class DroolsLspDocumentServiceTest {
+class DroolsLspDocumentServiceTest {
 
     @Test
-    public void testCompletion() {
+    void testCompletion() {
         DroolsLspDocumentService droolsLspDocumentService = getDroolsLspDocumentService("");
 
         CompletionParams completionParams = new CompletionParams();
@@ -40,11 +25,11 @@ public class DroolsLspDocumentServiceTest {
         completionParams.setPosition(caretPosition);
 
         List<CompletionItem> result = droolsLspDocumentService.getCompletionItems(completionParams);
-        assertTrue(result.stream().map(CompletionItem::getInsertText).anyMatch("package"::equals));
+        assertThat(result.stream().map(CompletionItem::getInsertText).anyMatch("package"::equals)).isTrue();
     }
 
     @Test
-    public void testReadRuleName() {
+    void testReadRuleName() {
         String drl = "rule MyRule when Dog(name == \"Bart\") then end";
 
         DroolsLspDocumentService droolsLspDocumentService = getDroolsLspDocumentService(drl);
@@ -53,19 +38,19 @@ public class DroolsLspDocumentServiceTest {
         completionParams.setTextDocument(new TextDocumentIdentifier("myDocument"));
 
         String ruleName = droolsLspDocumentService.getRuleName(completionParams);
-        assertEquals("MyRule", ruleName);
+        assertThat(ruleName).isEqualTo("MyRule");
     }
 
     @Test
-    public void testFindLHSandRHS() {
+    void testFindLHSandRHS() {
         String drl =
                 "package org.test;\n" +
-                "import org.test.model.Person;\n" +
-                "rule TestRule when\n" +
-                "  $p:Person() \n" +
-                "then\n" +
-                "  System.out.println($p.getName()); \n" +
-                "end";
+                        "import org.test.model.Person;\n" +
+                        "rule TestRule when\n" +
+                        "  $p:Person() \n" +
+                        "then\n" +
+                        "  System.out.println($p.getName()); \n" +
+                        "end";
 
         DroolsLspDocumentService droolsLspDocumentService = getDroolsLspDocumentService(drl);
 
@@ -74,16 +59,16 @@ public class DroolsLspDocumentServiceTest {
 
         completionParams.setPosition(new Position(1, 0));
         List<CompletionItem> result = droolsLspDocumentService.getCompletionItems(completionParams);
-        assertTrue(hasItem(result, "import"));
-        assertTrue(hasItem(result, "rule"));
+        assertThat(hasItem(result, "import")).isTrue();
+        assertThat(hasItem(result, "rule")).isTrue();
 
         completionParams.setPosition(new Position(3, 14));
         result = droolsLspDocumentService.getCompletionItems(completionParams);
-        assertTrue(hasItem(result, "then"));  // LHS
+        assertThat(hasItem(result, "then")).isTrue();  // LHS
 
         completionParams.setPosition(new Position(5, 36));
         result = droolsLspDocumentService.getCompletionItems(completionParams);
-        assertTrue(hasItem(result, "end")); // RHS
+        assertThat(hasItem(result, "end")).isTrue(); // RHS
     }
 
     private boolean hasItem(List<CompletionItem> result, String text) {

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/LauncherTest.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/LauncherTest.java
@@ -32,17 +32,19 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class LauncherTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class LauncherTest {
 
     private static final long TIMEOUT = 2000;
 
     @Test
-    public void testNotification() {
+    void testNotification() {
         MessageParams p = new MessageParams();
         p.setMessage("Hello World");
         p.setType(MessageType.Info);
@@ -53,9 +55,9 @@ public class LauncherTest {
     }
 
     @Test
-    public void testRequest() throws Exception {
+    void testRequest() throws Exception {
         CompletionParams p = new CompletionParams();
-        p.setPosition(new Position(1,1));
+        p.setPosition(new Position(1, 1));
         p.setTextDocument(new TextDocumentIdentifier("test/foo.txt"));
 
         CompletionList result = new CompletionList();
@@ -72,7 +74,7 @@ public class LauncherTest {
 
         server.expectedRequests.put("textDocument/completion", new Pair<>(p, result));
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> future = clientLauncher.getRemoteProxy().getTextDocumentService().completion(p);
-        Assert.assertEquals(Either.forRight(result).toString(), future.get(TIMEOUT, TimeUnit.MILLISECONDS).toString());
+        assertThat(future.get(TIMEOUT, TimeUnit.MILLISECONDS).toString()).isEqualTo(Either.forRight(result).toString());
         client.joinOnEmpty();
     }
 
@@ -82,9 +84,9 @@ public class LauncherTest {
 
         @Override
         public CompletableFuture<?> request(String method, Object parameter) {
-            Assert.assertTrue(expectedRequests.containsKey(method));
+            assertThat(expectedRequests.containsKey(method)).isTrue();
             Pair<Object, Object> result = expectedRequests.remove(method);
-            Assert.assertEquals(result.getKey().toString(), parameter.toString());
+            assertThat(parameter.toString()).isEqualTo(result.getKey().toString());
             return CompletableFuture.completedFuture(result.getValue());
         }
 
@@ -92,9 +94,9 @@ public class LauncherTest {
 
         @Override
         public void notify(String method, Object parameter) {
-            Assert.assertTrue(expectedNotifications.containsKey(method));
+            assertThat(expectedNotifications.containsKey(method)).isTrue();
             Object object = expectedNotifications.remove(method);
-            Assert.assertEquals(object.toString(), parameter.toString());
+            assertThat(parameter.toString()).isEqualTo(object.toString());
         }
 
         /**
@@ -113,7 +115,7 @@ public class LauncherTest {
                     e.printStackTrace();
                 }
             } while ( System.currentTimeMillis() < before + 1000);
-            Assert.fail("expectations weren't empty "+toString());
+            fail("", "expectations weren't empty " + toString());
         }
 
         @Override
@@ -133,7 +135,7 @@ public class LauncherTest {
 
     private Level logLevel;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         PipedInputStream inClient = new PipedInputStream();
         PipedOutputStream outClient = new PipedOutputStream();
@@ -155,7 +157,7 @@ public class LauncherTest {
         logger.setLevel(Level.SEVERE);
     }
 
-    @After
+    @AfterEach
     public void teardown() throws InterruptedException, ExecutionException {
         clientListening.cancel(true);
         serverListening.cancel(true);

--- a/drools-lsp-server/src/test/java/org/drools/lsp/server/TestHelperMethods.java
+++ b/drools-lsp-server/src/test/java/org/drools/lsp/server/TestHelperMethods.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.drools.lsp.server;
 
 import java.util.ArrayList;

--- a/drools-parser/pom.xml
+++ b/drools-parser/pom.xml
@@ -47,15 +47,21 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${version.org.assertj}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.org.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.org.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/drools-parser/src/test/java/org/drools/parser/DRLParserTest.java
+++ b/drools-parser/src/test/java/org/drools/parser/DRLParserTest.java
@@ -2,92 +2,98 @@ package org.drools.parser;
 
 import java.util.List;
 
-import org.drools.drl.ast.descr.*;
-import org.junit.Test;
+import org.drools.drl.ast.descr.AnnotationDescr;
+import org.drools.drl.ast.descr.AttributeDescr;
+import org.drools.drl.ast.descr.BaseDescr;
+import org.drools.drl.ast.descr.ExprConstraintDescr;
+import org.drools.drl.ast.descr.GlobalDescr;
+import org.drools.drl.ast.descr.PackageDescr;
+import org.drools.drl.ast.descr.PatternDescr;
+import org.drools.drl.ast.descr.RuleDescr;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.drools.parser.DRLParserHelper.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.drools.parser.DRLParserHelper.computeTokenIndex;
+import static org.drools.parser.DRLParserHelper.createDrlParser;
+import static org.drools.parser.DRLParserHelper.parse;
 
-public class DRLParserTest {
+class DRLParserTest {
 
     private static final String drl =
             "package org.test;\n" +
-            "import org.test.model.Person;\n" +
-            "global String result;\n" +
-            "rule TestRule @Test(true) no-loop salience 15 when \n" +
-            "  $p:Person( age >= 18 )\n" +
-            "then\n" +
-            "  int a = 4;\n" +
-            "  System.out.println($p.getName());\n" +
-            "end\n";
+                    "import org.test.model.Person;\n" +
+                    "global String result;\n" +
+                    "rule TestRule @Test(true) no-loop salience 15 when \n" +
+                    "  $p:Person( age >= 18 )\n" +
+                    "then\n" +
+                    "  int a = 4;\n" +
+                    "  System.out.println($p.getName());\n" +
+                    "end\n";
 
     @Test
-    public void testParse() {
+    void testParse() {
         PackageDescr packageDescr = parse(drl);
-        assertEquals("org.test", packageDescr.getName());
+        assertThat(packageDescr.getName()).isEqualTo("org.test");
 
-        assertEquals(1, packageDescr.getImports().size());
-        assertEquals("org.test.model.Person", packageDescr.getImports().get(0).getTarget());
+        assertThat(packageDescr.getImports().size()).isEqualTo(1);
+        assertThat(packageDescr.getImports().get(0).getTarget()).isEqualTo("org.test.model.Person");
 
-        assertEquals(1, packageDescr.getGlobals().size());
+        assertThat(packageDescr.getGlobals().size()).isEqualTo(1);
         GlobalDescr globalDescr = packageDescr.getGlobals().get(0);
-        assertEquals("String", globalDescr.getType());
-        assertEquals("result", globalDescr.getIdentifier());
+        assertThat(globalDescr.getType()).isEqualTo("String");
+        assertThat(globalDescr.getIdentifier()).isEqualTo("result");
 
-        assertEquals(1, packageDescr.getRules().size());
+        assertThat(packageDescr.getRules().size()).isEqualTo(1);
         RuleDescr ruleDescr = packageDescr.getRules().get(0);
 
         AnnotationDescr annotationDescr = ruleDescr.getAnnotation("Test");
-        assertNotNull(annotationDescr);
-        assertEquals("true", annotationDescr.getValue());
+        assertThat(annotationDescr).isNotNull();
+        assertThat(annotationDescr.getValue()).isEqualTo("true");
 
-        assertEquals(2, ruleDescr.getAttributes().size());
-        assertNotNull(ruleDescr.getAttributes().get("no-loop"));
+        assertThat(ruleDescr.getAttributes().size()).isEqualTo(2);
+        assertThat(ruleDescr.getAttributes().get("no-loop")).isNotNull();
         AttributeDescr salience = ruleDescr.getAttributes().get("salience");
-        assertNotNull(salience);
-        assertEquals("15", salience.getValue());
+        assertThat(salience).isNotNull();
+        assertThat(salience.getValue()).isEqualTo("15");
 
-        assertEquals("TestRule", ruleDescr.getName());
+        assertThat(ruleDescr.getName()).isEqualTo("TestRule");
 
-        assertEquals(1, ruleDescr.getLhs().getDescrs().size());
+        assertThat(ruleDescr.getLhs().getDescrs().size()).isEqualTo(1);
         PatternDescr patternDescr = (PatternDescr) ruleDescr.getLhs().getDescrs().get(0);
-        assertEquals("$p", patternDescr.getIdentifier());
-        assertEquals("Person", patternDescr.getObjectType());
+        assertThat(patternDescr.getIdentifier()).isEqualTo("$p");
+        assertThat(patternDescr.getObjectType()).isEqualTo("Person");
 
         List<? extends BaseDescr> constraints = patternDescr.getConstraint().getDescrs();
-        assertEquals(1, constraints.size());
+        assertThat(constraints.size()).isEqualTo(1);
         ExprConstraintDescr expr = (ExprConstraintDescr) constraints.get(0);
-        assertEquals("age >= 18", expr.getExpression());
+        assertThat(expr.getExpression()).isEqualTo("age >= 18");
 
         assertThat(ruleDescr.getConsequence().toString()).isEqualToIgnoringWhitespace("int a = 4; System.out.println($p.getName());");
     }
 
     @Test
-    public void testComputeTokenIndex() {
+    void testComputeTokenIndex() {
         DRLParser parser = createDrlParser(drl);
         parser.compilationUnit();
 
-        assertEquals(0, (int) computeTokenIndex(parser, 1, 0));
-        assertEquals(0, (int) computeTokenIndex(parser, 1, 1));
-        assertEquals(0, (int) computeTokenIndex(parser, 1, 7));
-        assertEquals(1, (int) computeTokenIndex(parser, 1, 8));
-        assertEquals(2, (int) computeTokenIndex(parser, 1, 9));
-        assertEquals(2, (int) computeTokenIndex(parser, 1, 9));
-        assertEquals(3, (int) computeTokenIndex(parser, 1, 12));
-        assertEquals(4, (int) computeTokenIndex(parser, 1, 13));
-        assertEquals(5, (int) computeTokenIndex(parser, 1, 17));
-        assertEquals(6, (int) computeTokenIndex(parser, 1, 18));
-        assertEquals(6, (int) computeTokenIndex(parser, 2, 0));
-        assertEquals(7, (int) computeTokenIndex(parser, 2, 1));
-        assertEquals(7, (int) computeTokenIndex(parser, 2, 6));
-        assertEquals(8, (int) computeTokenIndex(parser, 2, 7));
-        assertEquals(80, (int) computeTokenIndex(parser, 9, 0));
-        assertEquals(81, (int) computeTokenIndex(parser, 9, 1));
-        assertEquals(82, (int) computeTokenIndex(parser, 9, 4));
-        assertEquals(82, (int) computeTokenIndex(parser, 9, 5));
-        assertEquals(82, (int) computeTokenIndex(parser, 10, 0));  // EOF
+        assertThat((int) computeTokenIndex(parser, 1, 0)).isEqualTo(0);
+        assertThat((int) computeTokenIndex(parser, 1, 1)).isEqualTo(0);
+        assertThat((int) computeTokenIndex(parser, 1, 7)).isEqualTo(0);
+        assertThat((int) computeTokenIndex(parser, 1, 8)).isEqualTo(1);
+        assertThat((int) computeTokenIndex(parser, 1, 9)).isEqualTo(2);
+        assertThat((int) computeTokenIndex(parser, 1, 9)).isEqualTo(2);
+        assertThat((int) computeTokenIndex(parser, 1, 12)).isEqualTo(3);
+        assertThat((int) computeTokenIndex(parser, 1, 13)).isEqualTo(4);
+        assertThat((int) computeTokenIndex(parser, 1, 17)).isEqualTo(5);
+        assertThat((int) computeTokenIndex(parser, 1, 18)).isEqualTo(6);
+        assertThat((int) computeTokenIndex(parser, 2, 0)).isEqualTo(6);
+        assertThat((int) computeTokenIndex(parser, 2, 1)).isEqualTo(7);
+        assertThat((int) computeTokenIndex(parser, 2, 6)).isEqualTo(7);
+        assertThat((int) computeTokenIndex(parser, 2, 7)).isEqualTo(8);
+        assertThat((int) computeTokenIndex(parser, 9, 0)).isEqualTo(80);
+        assertThat((int) computeTokenIndex(parser, 9, 1)).isEqualTo(81);
+        assertThat((int) computeTokenIndex(parser, 9, 4)).isEqualTo(82);
+        assertThat((int) computeTokenIndex(parser, 9, 5)).isEqualTo(82);
+        assertThat((int) computeTokenIndex(parser, 10, 0)).isEqualTo(82);  // EOF
     }
-
 }

--- a/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
+++ b/drools-parser/src/test/java/org/drools/parser/MiscDRLParserTest.java
@@ -2,15 +2,11 @@ package org.drools.parser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import junit.framework.TestCase;
-import org.assertj.core.api.Assertions;
 import org.drools.drl.ast.descr.AndDescr;
 import org.drools.drl.ast.descr.AttributeDescr;
 import org.drools.drl.ast.descr.BaseDescr;
@@ -26,28 +22,26 @@ import org.drools.drl.ast.descr.OrDescr;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.drools.drl.ast.descr.PatternDescr;
 import org.drools.drl.ast.descr.RuleDescr;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
  * This test class is being ported from org.drools.mvel.compiler.lang.RuleParserTest
  */
-public class MiscDRLParserTest extends TestCase {
+class MiscDRLParserTest {
 
     private DRLParserWrapper parser;
 
-    @Before
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeEach
+    public void setUp() {
         parser = new DRLParserWrapper();
     }
 
-    @After
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @AfterEach
+    public void tearDown() {
     }
 
     private String readResource(final String filename) throws Exception {
@@ -64,202 +58,151 @@ public class MiscDRLParserTest extends TestCase {
     }
 
     @Test
-    public void testPackage() throws Exception {
+    void testPackage() {
         final String source = "package foo.bar.baz";
         final PackageDescr pkg = parser.parse(source);
-        assertEquals("foo.bar.baz", pkg.getName());
+        assertThat(pkg.getName()).isEqualTo("foo.bar.baz");
     }
 
     @Test
-    public void testPackageWithErrorNode() throws Exception {
+    void testPackageWithErrorNode() {
         final String source = "package 12 foo.bar.baz";
         final PackageDescr pkg = parser.parse(source);
-        assertTrue(parser.hasErrors());
-        assertEquals("foo.bar.baz", pkg.getName());
+        assertThat(parser.hasErrors()).isTrue();
+        assertThat(pkg.getName()).isEqualTo("foo.bar.baz");
     }
 
     @Test
-    public void testPackageWithAllErrorNode() throws Exception {
+    void testPackageWithAllErrorNode() {
         final String source = "package 12 12312 231";
         final PackageDescr pkg = parser.parse(source);
-        assertTrue(parser.hasErrors());
-        assertEquals("", pkg.getName());
+        assertThat(parser.hasErrors()).isTrue();
+        assertThat(pkg.getName()).isEqualTo("");
     }
 
     @Test
-    public void testCompilationUnit() throws Exception {
+    void testCompilationUnit() {
         final String source = "package foo; import com.foo.Bar; import com.foo.Baz;";
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
-        assertEquals("foo",
-                     pkg.getName());
-        assertEquals(2,
-                     pkg.getImports().size());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        assertThat(pkg.getName()).isEqualTo("foo");
+        assertThat(pkg.getImports().size()).isEqualTo(2);
         ImportDescr impdescr = pkg.getImports().get(0);
-        assertEquals("com.foo.Bar",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length(),
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("com.foo.Bar");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()));
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length());
 
         impdescr = pkg.getImports().get(1);
-        assertEquals("com.foo.Baz",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length(),
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("com.foo.Baz");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()));
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length());
     }
 
     @Test
-    public void testFunctionImport() throws Exception {
+    void testFunctionImport() {
         final String source = "package foo\n" +
                 "import function java.lang.Math.max\n" +
                 "import function java.lang.Math.min;\n" +
                 "import foo.bar.*\n" +
                 "import baz.Baz";
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
-        assertEquals("foo",
-                     pkg.getName());
-        assertEquals(2,
-                     pkg.getImports().size());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        assertThat(pkg.getName()).isEqualTo("foo");
+        assertThat(pkg.getImports().size()).isEqualTo(2);
         ImportDescr impdescr = pkg.getImports().get(0);
-        assertEquals("foo.bar.*",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("foo.bar.*");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()));
 
-        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1,
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1);
 
         impdescr = pkg.getImports().get(1);
-        assertEquals("baz.Baz",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1,
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("baz.Baz");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()));
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1);
 
-        assertEquals(2,
-                     pkg.getFunctionImports().size());
+        assertThat(pkg.getFunctionImports().size()).isEqualTo(2);
         impdescr = pkg.getFunctionImports().get(0);
-        assertEquals("java.lang.Math.max",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import function " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
-        assertEquals(source.indexOf("import function " + impdescr.getTarget()) + ("import function " + impdescr.getTarget()).length() - 1,
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("java.lang.Math.max");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import function " + impdescr.getTarget()));
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import function " + impdescr.getTarget()) + ("import function " + impdescr.getTarget()).length() - 1);
 
         impdescr = pkg.getFunctionImports().get(1);
-        assertEquals("java.lang.Math.min",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import function " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
-        assertEquals(source.indexOf("import function " + impdescr.getTarget()) + ("import function " + impdescr.getTarget()).length(),
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("java.lang.Math.min");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import function " + impdescr.getTarget()));
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import function " + impdescr.getTarget()) + ("import function " + impdescr.getTarget()).length());
     }
 
     @Test
-    public void testGlobalWithComplexType() throws Exception {
+    void testGlobalWithComplexType() {
         final String source = "package foo.bar.baz\n" +
                 "import com.foo.Bar\n" +
                 "global java.util.List<java.util.Map<String,Integer>> aList;\n" +
                 "global Integer aNumber";
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
-        assertEquals("foo.bar.baz",
-                     pkg.getName());
-        assertEquals(1,
-                     pkg.getImports().size());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        assertThat(pkg.getName()).isEqualTo("foo.bar.baz");
+        assertThat(pkg.getImports().size()).isEqualTo(1);
 
         ImportDescr impdescr = pkg.getImports().get(0);
-        assertEquals("com.foo.Bar",
-                     impdescr.getTarget());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()),
-                     impdescr.getStartCharacter());
-        assertEquals(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1,
-                     impdescr.getEndCharacter());
+        assertThat(impdescr.getTarget()).isEqualTo("com.foo.Bar");
+        assertThat(impdescr.getStartCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()));
+        assertThat(impdescr.getEndCharacter()).isEqualTo(source.indexOf("import " + impdescr.getTarget()) + ("import " + impdescr.getTarget()).length() - 1);
 
-        assertEquals(2,
-                     pkg.getGlobals().size());
+        assertThat(pkg.getGlobals().size()).isEqualTo(2);
 
         GlobalDescr global = pkg.getGlobals().get(0);
-        assertEquals("java.util.List<java.util.Map<String,Integer>>",
-                     global.getType());
-        assertEquals("aList",
-                     global.getIdentifier());
-        assertEquals(source.indexOf("global " + global.getType()),
-                     global.getStartCharacter());
-        assertEquals(source.indexOf("global " + global.getType() + " " + global.getIdentifier()) +
-                             ("global " + global.getType() + " " + global.getIdentifier()).length(),
-                     global.getEndCharacter());
+        assertThat(global.getType()).isEqualTo("java.util.List<java.util.Map<String,Integer>>");
+        assertThat(global.getIdentifier()).isEqualTo("aList");
+        assertThat(global.getStartCharacter()).isEqualTo(source.indexOf("global " + global.getType()));
+        assertThat(global.getEndCharacter()).isEqualTo(source.indexOf("global " + global.getType() + " " + global.getIdentifier()) +
+                                                               ("global " + global.getType() + " " + global.getIdentifier()).length());
 
         global = pkg.getGlobals().get(1);
-        assertEquals("Integer",
-                     global.getType());
-        assertEquals("aNumber",
-                     global.getIdentifier());
-        assertEquals(source.indexOf("global " + global.getType()),
-                     global.getStartCharacter());
-        assertEquals(source.indexOf("global " + global.getType() + " " + global.getIdentifier()) +
-                             ("global " + global.getType() + " " + global.getIdentifier()).length() - 1,
-                     global.getEndCharacter());
+        assertThat(global.getType()).isEqualTo("Integer");
+        assertThat(global.getIdentifier()).isEqualTo("aNumber");
+        assertThat(global.getStartCharacter()).isEqualTo(source.indexOf("global " + global.getType()));
+        assertThat(global.getEndCharacter()).isEqualTo(source.indexOf("global " + global.getType() + " " + global.getIdentifier()) +
+                                                               ("global " + global.getType() + " " + global.getIdentifier()).length() - 1);
     }
 
     @Test
-    public void testGlobalWithOrWithoutSemi() throws Exception {
+    void testGlobalWithOrWithoutSemi() throws Exception {
         String source = readResource("globals.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertEquals(1,
-                     pkg.getRules().size());
+        assertThat(pkg.getRules().size()).isEqualTo(1);
 
         final RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-        assertEquals(1,
-                     rule.getLhs().getDescrs().size());
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
 
-        assertEquals(1,
-                     pkg.getImports().size());
-        assertEquals(2,
-                     pkg.getGlobals().size());
+        assertThat(pkg.getImports().size()).isEqualTo(1);
+        assertThat(pkg.getGlobals().size()).isEqualTo(2);
 
         final GlobalDescr foo = (GlobalDescr) pkg.getGlobals().get(0);
-        assertEquals("java.lang.String",
-                     foo.getType());
-        assertEquals("foo",
-                     foo.getIdentifier());
+        assertThat(foo.getType()).isEqualTo("java.lang.String");
+        assertThat(foo.getIdentifier()).isEqualTo("foo");
         final GlobalDescr bar = (GlobalDescr) pkg.getGlobals().get(1);
-        assertEquals("java.lang.Integer",
-                     bar.getType());
-        assertEquals("bar",
-                     bar.getIdentifier());
+        assertThat(bar.getType()).isEqualTo("java.lang.Integer");
+        assertThat(bar.getIdentifier()).isEqualTo("bar");
     }
 
     @Test
-    public void testFunctionImportWithNotExist() throws Exception {
+    void testFunctionImportWithNotExist() throws Exception {
         String source = readResource("test_FunctionImport.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertEquals(2,
-                     pkg.getFunctionImports().size());
+        assertThat(pkg.getFunctionImports().size()).isEqualTo(2);
 
-        assertEquals("abd.def.x",
-                     ((FunctionImportDescr) pkg.getFunctionImports().get(0)).getTarget());
-        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getStartCharacter() == -1);
-        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getEndCharacter() == -1);
-        assertEquals("qed.wah.*",
-                     ((FunctionImportDescr) pkg.getFunctionImports().get(1)).getTarget());
-        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getStartCharacter() == -1);
-        assertFalse(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getEndCharacter() == -1);
+        assertThat(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getTarget()).isEqualTo("abd.def.x");
+        assertThat(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getStartCharacter() == -1).isFalse();
+        assertThat(((FunctionImportDescr) pkg.getFunctionImports().get(0)).getEndCharacter() == -1).isFalse();
+        assertThat(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getTarget()).isEqualTo("qed.wah.*");
+        assertThat(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getStartCharacter() == -1).isFalse();
+        assertThat(((FunctionImportDescr) pkg.getFunctionImports().get(1)).getEndCharacter() == -1).isFalse();
     }
 
     @Test
-    public void testFromComplexAcessor() throws Exception {
+    void testFromComplexAcessor() {
         String source = "rule \"Invalid customer id\" ruleflow-group \"validate\" lock-on-active true \n" +
                 " when \n" +
                 "     o: Order( ) \n" +
@@ -271,27 +214,22 @@ public class MiscDRLParserTest extends TestCase {
                 "end \n";
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse(parser.getErrorMessages().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrorMessages().toString()).isFalse();
 
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-        assertEquals("Invalid customer id",
-                     rule.getName());
+        assertThat(rule.getName()).isEqualTo("Invalid customer id");
 
-        assertEquals(2,
-                     rule.getLhs().getDescrs().size());
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(2);
 
         NotDescr not = (NotDescr) rule.getLhs().getDescrs().get(1);
         PatternDescr customer = (PatternDescr) not.getDescrs().get(0);
 
-        assertEquals("Customer",
-                     customer.getObjectType());
-        assertEquals("customerService.getCustomer(o.getCustomerId())",
-                     ((FromDescr) customer.getSource()).getDataSource().getText());
+        assertThat(customer.getObjectType()).isEqualTo("Customer");
+        assertThat(((FromDescr) customer.getSource()).getDataSource().getText()).isEqualTo("customerService.getCustomer(o.getCustomerId())");
     }
 
     @Test
-    public void testFromWithInlineList() throws Exception {
+    void testFromWithInlineList() {
         String source = "rule XYZ \n" +
                 " when \n" +
                 " o: Order( ) \n" +
@@ -301,19 +239,17 @@ public class MiscDRLParserTest extends TestCase {
                 " o.addError(\"Invalid customer id\"); \n" +
                 "end \n";
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-        assertEquals("XYZ",
-                     rule.getName());
+        assertThat(rule.getName()).isEqualTo("XYZ");
 
         PatternDescr number = (PatternDescr) ((NotDescr) rule.getLhs().getDescrs().get(1)).getDescrs().get(0);
         assertThat(((FromDescr) number.getSource()).getDataSource().toString()).isEqualToIgnoringWhitespace("[1, 2, 3]");
     }
 
     @Test
-    public void testFromWithInlineListMethod() throws Exception {
+    void testFromWithInlineListMethod() {
         String source = "rule XYZ \n" +
                 " when \n" +
                 " o: Order( ) \n" +
@@ -323,21 +259,19 @@ public class MiscDRLParserTest extends TestCase {
                 " o.addError(\"Invalid customer id\"); \n" +
                 "end \n";
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-        assertEquals("XYZ",
-                     rule.getName());
+        assertThat(rule.getName()).isEqualTo("XYZ");
 
-        assertFalse(parser.hasErrors());
+        assertThat(parser.hasErrors()).isFalse();
         PatternDescr number = (PatternDescr) rule.getLhs().getDescrs().get(1);
 
         assertThat(((FromDescr) number.getSource()).getDataSource().toString()).isEqualToIgnoringWhitespace("[1, 2, 3].sublist(1, 2)");
     }
 
     @Test
-    public void testFromWithInlineListIndex() throws Exception {
+    void testFromWithInlineListIndex() {
         String source = "rule XYZ \n" +
                 " when \n" +
                 " o: Order( ) \n" +
@@ -348,31 +282,29 @@ public class MiscDRLParserTest extends TestCase {
                 "end \n";
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-        assertEquals("XYZ",
-                     rule.getName());
+        assertThat(rule.getName()).isEqualTo("XYZ");
 
-        assertFalse(parser.hasErrors());
+        assertThat(parser.hasErrors()).isFalse();
         PatternDescr number = (PatternDescr) rule.getLhs().getDescrs().get(1);
         assertThat(((FromDescr) number.getSource()).getDataSource().toString()).isEqualToIgnoringWhitespace("[1, 2, 3][1]");
     }
 
     @Test
-    public void testRuleWithoutEnd() throws Exception {
+    void testRuleWithoutEnd() {
         String source = "rule \"Invalid customer id\" \n" +
                 " when \n" +
                 " o: Order( ) \n" +
                 " then \n" +
                 " System.err.println(\"Invalid customer id found!\"); \n";
         parser.parse(source);
-        assertTrue(parser.hasErrors());
+        assertThat(parser.hasErrors()).isTrue();
     }
 
     @Test
-    public void testOrWithSpecialBind() throws Exception {
+    void testOrWithSpecialBind() {
         String source = "rule \"A and (B or C or D)\" \n" +
                 "    when \n" +
                 "        pdo1 : ParametricDataObject( paramID == 101, stringValue == \"1000\" ) and \n" +
@@ -383,122 +315,98 @@ public class MiscDRLParserTest extends TestCase {
                 "        System.out.println( \"Rule: A and (B or C or D) Fired. pdo1: \" + pdo1 +  \" pdo2: \"+ pdo2); \n" +
                 "end\n";
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = pkg.getRules().get(0);
         AndDescr lhs = rule.getLhs();
-        assertEquals(2,
-                     lhs.getDescrs().size());
+        assertThat(lhs.getDescrs().size()).isEqualTo(2);
 
         PatternDescr pdo1 = (PatternDescr) lhs.getDescrs().get(0);
-        assertEquals("pdo1",
-                     pdo1.getIdentifier());
+        assertThat(pdo1.getIdentifier()).isEqualTo("pdo1");
 
         OrDescr or = (OrDescr) rule.getLhs().getDescrs().get(1);
-        assertEquals(3,
-                     or.getDescrs().size());
+        assertThat(or.getDescrs().size()).isEqualTo(3);
         for (BaseDescr pdo2 : or.getDescrs()) {
-            assertEquals("pdo2",
-                         ((PatternDescr) pdo2).getIdentifier());
+            assertThat(((PatternDescr) pdo2).getIdentifier()).isEqualTo("pdo2");
         }
     }
 
     @Test
-    public void testCompatibleRestriction() throws Exception {
+    void testCompatibleRestriction() {
         String source = "package com.sample  rule test  when  Test( ( text == null || text2 matches \"\" ) )  then  end";
         PackageDescr pkg = parser.parse(source);
 
-        assertEquals( "com.sample",
-                      pkg.getName() );
-        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
-        assertEquals( "test",
-                      rule.getName() );
-        ExprConstraintDescr expr = (ExprConstraintDescr) ((PatternDescr) rule.getLhs().getDescrs().get(0 )).getDescrs().get(0 );
-        assertEquals( "( text == null || text2 matches \"\" )",
-                      expr.getText() );
+        assertThat(pkg.getName()).isEqualTo("com.sample");
+        RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
+        assertThat(rule.getName()).isEqualTo("test");
+        ExprConstraintDescr expr = (ExprConstraintDescr) ((PatternDescr) rule.getLhs().getDescrs().get(0)).getDescrs().get(0);
+        assertThat(expr.getText()).isEqualTo("( text == null || text2 matches \"\" )");
     }
 
     @Test
-    public void testSimpleConstraint() throws Exception {
+    void testSimpleConstraint() {
         String source = "package com.sample  rule test  when  Cheese( type == 'stilton', price > 10 )  then  end";
         PackageDescr pkg = parser.parse(source);
 
-        assertEquals( "com.sample",
-                      pkg.getName() );
-        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
-        assertEquals( "test",
-                      rule.getName() );
+        assertThat(pkg.getName()).isEqualTo("com.sample");
+        RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
+        assertThat(rule.getName()).isEqualTo("test");
 
-        assertEquals( 1,
-                      rule.getLhs().getDescrs().size() );
-        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
 
         AndDescr constraint = (AndDescr) pattern.getConstraint();
-        assertEquals( 2,
-                      constraint.getDescrs().size() );
-        assertEquals( "type == \"stilton\"",
-                      constraint.getDescrs().get( 0 ).toString() );
-        assertEquals( "price > 10",
-                      constraint.getDescrs().get( 1 ).toString() );
+        assertThat(constraint.getDescrs().size()).isEqualTo(2);
+        assertThat(constraint.getDescrs().get(0).toString()).isEqualTo("type == \"stilton\"");
+        assertThat(constraint.getDescrs().get(1).toString()).isEqualTo("price > 10");
     }
 
     @Test
-    public void testStringEscapes() throws Exception {
+    void testStringEscapes() {
         String source = "package com.sample  rule test  when  Cheese( type matches \"\\..*\\\\.\" )  then  end";
         PackageDescr pkg = parser.parse(source);
-        assertEquals( "com.sample",
-                      pkg.getName() );
-        RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
-        assertEquals( "test",
-                      rule.getName() );
+        assertThat(pkg.getName()).isEqualTo("com.sample");
+        RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
+        assertThat(rule.getName()).isEqualTo("test");
 
-        assertEquals( 1,
-                      rule.getLhs().getDescrs().size() );
-        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get( 0 );
+        assertThat(rule.getLhs().getDescrs().size()).isEqualTo(1);
+        PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
 
         AndDescr constraint = (AndDescr) pattern.getConstraint();
-        assertEquals( 1,
-                      constraint.getDescrs().size() );
-        assertEquals( "type matches \"\\..*\\\\.\"",
-                      constraint.getDescrs().get( 0 ).toString() );
+        assertThat(constraint.getDescrs().size()).isEqualTo(1);
+        assertThat(constraint.getDescrs().get(0).toString()).isEqualTo("type matches \"\\..*\\\\.\"");
     }
 
     @Test
-    public void testDialect() throws Exception {
+    void testDialect() {
         final String source = "dialect 'mvel'";
         PackageDescr pkg = parser.parse(source);
         AttributeDescr attr = (AttributeDescr) pkg.getAttributes().get(0);
-        assertEquals("dialect",
-                     attr.getName());
-        assertEquals("mvel",
-                     attr.getValue());
+        assertThat(attr.getName()).isEqualTo("dialect");
+        assertThat(attr.getValue()).isEqualTo("mvel");
     }
 
     @Test
-    public void testDialect2() throws Exception {
+    void testDialect2() {
         final String source = "dialect \"mvel\"";
         PackageDescr pkg = parser.parse(source);
         AttributeDescr attr = pkg.getAttributes().get(0);
-        assertEquals("dialect",
-                     attr.getName());
-        assertEquals("mvel",
-                     attr.getValue());
+        assertThat(attr.getName()).isEqualTo("dialect");
+        assertThat(attr.getValue()).isEqualTo("mvel");
     }
 
     @Test
-    public void testEmptyRuleWithoutWhen() throws Exception {
+    void testEmptyRuleWithoutWhen() throws Exception {
         String source = readResource("empty_rule.drl"); // without WHEN
         PackageDescr pkg = parser.parse(source);
 
-        assertTrue(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isTrue();
 
         // Note : RuleParserTest.testEmptyRule allows this DRL, but I think is doesn't make sense to pass this DRL
     }
 
     @Test
-    public void testKeywordCollisions() throws Exception {
+    void testKeywordCollisions() throws Exception {
         String source = readResource("eol_funny_business.drl"); // keywords everywhere
 
         // Note: eol_funny_business.drl is modified from the one under drools-test-coverage to be more realistic.
@@ -506,27 +414,24 @@ public class MiscDRLParserTest extends TestCase {
 
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
-        assertEquals( 1,
-                      pkg.getRules().size() );
+        assertThat(pkg.getRules().size()).isEqualTo(1);
     }
 
     @Test
-    public void testTernaryExpression() throws Exception {
+    void testTernaryExpression() throws Exception {
         String source = readResource("ternary_expression.drl");
         PackageDescr pkg = parser.parse(source);
 
-        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
-        assertEquals( 1,
-                      pkg.getRules().size() );
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
+        assertThat(pkg.getRules().size()).isEqualTo(1);
 
         assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace("if (speed > speedLimit ? true : false;) pullEmOver();");
     }
 
     @Test
-    public void testFunctionWithArrays() throws Exception {
+    void testFunctionWithArrays() throws Exception {
         String source = readResource("function_arrays.drl");
 
         // Note: function_arrays.drl is modified from the one under drools-test-coverage to be more realistic.
@@ -535,137 +440,112 @@ public class MiscDRLParserTest extends TestCase {
 
         PackageDescr pkg = parser.parse(source);
 
-        assertEquals( "foo",
-                      pkg.getName() );
-        assertEquals( 1,
-                      pkg.getRules().size() );
+        assertThat(pkg.getName()).isEqualTo("foo");
+        assertThat(pkg.getRules().size()).isEqualTo(1);
 
-        final RuleDescr rule = (RuleDescr) pkg.getRules().get( 0 );
+        final RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
 
         assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace("yourFunction(new String[] {\"a\",\"b\",\"c\"});");
 
-        final FunctionDescr func = (FunctionDescr) pkg.getFunctions().get(0 );
+        final FunctionDescr func = (FunctionDescr) pkg.getFunctions().get(0);
 
-        assertEquals( "String[]",
-                      func.getReturnType() );
-        assertEquals( "args[]",
-                      func.getParameterNames().get( 0 ) );
-        assertEquals( "String",
-                      func.getParameterTypes().get( 0 ) );
+        assertThat(func.getReturnType()).isEqualTo("String[]");
+        assertThat(func.getParameterNames().get(0)).isEqualTo("args[]");
+        assertThat(func.getParameterTypes().get(0)).isEqualTo("String");
     }
 
     @Test
-    public void testAlmostEmptyRule() throws Exception {
+    void testAlmostEmptyRule() throws Exception {
         String source = readResource("almost_empty_rule.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
-        assertNotNull( pkg );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
+        assertThat(pkg).isNotNull();
 
-        RuleDescr rule = pkg.getRules().get( 0 );
+        RuleDescr rule = pkg.getRules().get(0);
 
-        assertEquals( "almost_empty",
-                      rule.getName() );
-        assertNotNull( rule.getLhs() );
-        assertEquals( "",
-                      ((String) rule.getConsequence()).trim() );
+        assertThat(rule.getName()).isEqualTo("almost_empty");
+        assertThat(rule.getLhs()).isNotNull();
+        assertThat(((String) rule.getConsequence()).trim()).isEqualTo("");
     }
 
     @Test
-    public void testQuotedStringNameRule() throws Exception {
+    void testQuotedStringNameRule() throws Exception {
         String source = readResource("quoted_string_name_rule.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = pkg.getRules().get(0);
-        assertNotNull( rule );
+        assertThat(rule).isNotNull();
 
-        assertEquals( "quoted string name",
-                      rule.getName() );
-        assertNotNull( rule.getLhs() );
-        assertEquals( "",
-                      ((String) rule.getConsequence()).trim() );
+        assertThat(rule.getName()).isEqualTo("quoted string name");
+        assertThat(rule.getLhs()).isNotNull();
+        assertThat(((String) rule.getConsequence()).trim()).isEqualTo("");
     }
 
     @Test
-    public void testNoLoop() throws Exception {
+    void testNoLoop() throws Exception {
         String source = readResource("no-loop.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = pkg.getRules().get(0);
-        assertNotNull( rule );
+        assertThat(rule).isNotNull();
 
-        assertEquals( "rule1",
-                      rule.getName() );
-        final AttributeDescr att = (AttributeDescr) rule.getAttributes().get( "no-loop" );
-        assertEquals( "false",
-                      att.getValue() );
-        assertEquals( "no-loop",
-                      att.getName() );
+        assertThat(rule.getName()).isEqualTo("rule1");
+        final AttributeDescr att = (AttributeDescr) rule.getAttributes().get("no-loop");
+        assertThat(att.getValue()).isEqualTo("false");
+        assertThat(att.getName()).isEqualTo("no-loop");
     }
 
     @Test
-    public void testAutofocus() throws Exception {
+    void testAutofocus() throws Exception {
         String source = readResource("autofocus.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = pkg.getRules().get(0);
-        assertNotNull( rule );
+        assertThat(rule).isNotNull();
 
-        assertEquals( "rule1",
-                      rule.getName() );
-        final AttributeDescr att = (AttributeDescr) rule.getAttributes().get( "auto-focus" );
-        assertEquals( "true",
-                      att.getValue() );
-        assertEquals( "auto-focus",
-                      att.getName() );
+        assertThat(rule.getName()).isEqualTo("rule1");
+        final AttributeDescr att = (AttributeDescr) rule.getAttributes().get("auto-focus");
+        assertThat(att.getValue()).isEqualTo("true");
+        assertThat(att.getName()).isEqualTo("auto-focus");
     }
 
     @Test
-    public void testRuleFlowGroup() throws Exception {
+    void testRuleFlowGroup() throws Exception {
         String source = readResource("ruleflowgroup.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = pkg.getRules().get(0);
-        assertNotNull( rule );
+        assertThat(rule).isNotNull();
 
-        assertEquals( "rule1",
-                      rule.getName() );
-        final AttributeDescr att = (AttributeDescr) rule.getAttributes().get( "ruleflow-group" );
-        assertEquals( "a group",
-                      att.getValue() );
-        assertEquals( "ruleflow-group",
-                      att.getName() );
+        assertThat(rule.getName()).isEqualTo("rule1");
+        final AttributeDescr att = (AttributeDescr) rule.getAttributes().get("ruleflow-group");
+        assertThat(att.getValue()).isEqualTo("a group");
+        assertThat(att.getName()).isEqualTo("ruleflow-group");
     }
 
     @Test
-    public void testConsequenceWithDeclaration() throws Exception {
+    void testConsequenceWithDeclaration() throws Exception {
         String source = readResource("declaration-in-consequence.drl");
         PackageDescr pkg = parser.parse(source);
 
         // Note : Removed "i\i;" from the original declaration-in-consequence.drl under drools-test-coverage
         // because it's not a valid java expression and doesn't make sense to test. (Right to raise a parser error)
 
-        assertFalse( parser.getErrors().toString(),
-                     parser.hasErrors() );
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
         RuleDescr rule = pkg.getRules().get(0);
-        assertNotNull( rule );
+        assertThat(rule).isNotNull();
 
-        assertEquals( "myrule",
-                      rule.getName() );
+        assertThat(rule.getName()).isEqualTo("myrule");
 
         final String expected = "int i = 0; i = 1; i / 1; i == 1; i(i); i = 'i'; i.i.i; i<i; i>i; i=\"i\";  ++i;" +
                 "i++; --i; i--; i += i; i -= i; i *= i; i /= i;" +
@@ -675,42 +555,38 @@ public class MiscDRLParserTest extends TestCase {
                 "String s = (String) o;";
 
         assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace(expected);
-        assertTrue( ((String) rule.getConsequence()).indexOf( "++" ) > 0 );
-        assertTrue( ((String) rule.getConsequence()).indexOf( "--" ) > 0 );
-        assertTrue( ((String) rule.getConsequence()).indexOf( "+=" ) > 0 );
-        assertTrue( ((String) rule.getConsequence()).indexOf( "==" ) > 0 );
-        assertTrue( ((String) rule.getConsequence()).indexOf( "i++" ) > 0 );
+        assertThat(((String) rule.getConsequence()).indexOf("++") > 0).isTrue();
+        assertThat(((String) rule.getConsequence()).indexOf("--") > 0).isTrue();
+        assertThat(((String) rule.getConsequence()).indexOf("+=") > 0).isTrue();
+        assertThat(((String) rule.getConsequence()).indexOf("==") > 0).isTrue();
+        assertThat(((String) rule.getConsequence()).indexOf("i++") > 0).isTrue();
         // note, need to assert that "i++" is preserved as is, no extra spaces.
     }
 
     @Test
-    public void testRuleParseLhs() throws Exception {
+    void testRuleParseLhs() {
         final String text = "rule X when Person(age < 42, location==\"atlanta\") \nor\nPerson(name==\"bob\") then end";
         PackageDescr pkg = parser.parse(text);
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
 
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
-        assertNotNull(rule);
+        assertThat(rule).isNotNull();
 
         AndDescr lhs = rule.getLhs();
-        assertEquals(1,
-                     lhs.getDescrs().size());
-        assertEquals(2,
-                     ((OrDescr) lhs.getDescrs().get(0)).getDescrs().size());
+        assertThat(lhs.getDescrs().size()).isEqualTo(1);
+        assertThat(((OrDescr) lhs.getDescrs().get(0)).getDescrs().size()).isEqualTo(2);
     }
 
     @Test
-    public void testRuleParseLhsWithStringQuotes() throws Exception {
+    void testRuleParseLhsWithStringQuotes() {
         final String text = "rule X when Person( location==\"atlanta\\\"\") then end\n";
         PackageDescr pkg = parser.parse(text);
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
 
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
-        assertNotNull(rule);
+        assertThat(rule).isNotNull();
 
         AndDescr lhs = rule.getLhs();
         ExprConstraintDescr constr = (ExprConstraintDescr) ((PatternDescr) lhs.getDescrs().get(0)).getDescrs().get(0);
@@ -719,14 +595,13 @@ public class MiscDRLParserTest extends TestCase {
     }
 
     @Test
-    public void testRuleParseLhsWithStringQuotes2() throws Exception {
+    void testRuleParseLhsWithStringQuotes2() {
         final String text = "rule X when Cheese( $x: type, type == \"s\\tti\\\"lto\\nn\" ) then end\n";
         PackageDescr pkg = parser.parse(text);
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
-        assertNotNull(rule);
+        assertThat(rule).isNotNull();
 
         AndDescr lhs = rule.getLhs();
         ExprConstraintDescr constr = (ExprConstraintDescr) ((PatternDescr) lhs.getDescrs().get(0)).getDescrs().get(1);
@@ -735,36 +610,31 @@ public class MiscDRLParserTest extends TestCase {
     }
 
     @Test
-    public void testLiteralBoolAndNegativeNumbersRule() throws Exception {
+    void testLiteralBoolAndNegativeNumbersRule() throws Exception {
         String source = readResource("literal_bool_and_negative.drl");
         PackageDescr pkg = parser.parse(source);
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
 
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
-        assertNotNull(rule);
+        assertThat(rule).isNotNull();
 
-        assertEquals("simple_rule",
-                     rule.getName());
-        assertNotNull(rule.getLhs());
+        assertThat(rule.getName()).isEqualTo("simple_rule");
+        assertThat(rule.getLhs()).isNotNull();
 
         assertThat((String) rule.getConsequence()).isEqualToIgnoringWhitespace("cons();");
 
         final AndDescr lhs = rule.getLhs();
-        assertEquals(3,
-                     lhs.getDescrs().size());
+        assertThat(lhs.getDescrs().size()).isEqualTo(3);
 
         PatternDescr pattern = (PatternDescr) lhs.getDescrs().get(0);
-        assertEquals(1,
-                     pattern.getConstraint().getDescrs().size());
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(1);
         AndDescr fieldAnd = (AndDescr) pattern.getConstraint();
         ExprConstraintDescr fld = (ExprConstraintDescr) fieldAnd.getDescrs().get(0);
         assertThat(fld.getExpression()).isEqualToIgnoringWhitespace("bar == false");
 
         pattern = (PatternDescr) lhs.getDescrs().get(1);
-        assertEquals(1,
-                     pattern.getConstraint().getDescrs().size());
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(1);
 
         fieldAnd = (AndDescr) pattern.getConstraint();
         fld = (ExprConstraintDescr) fieldAnd.getDescrs().get(0);
@@ -772,8 +642,7 @@ public class MiscDRLParserTest extends TestCase {
         assertThat(fld.getText()).isEqualToIgnoringWhitespace("boo > -42");
 
         pattern = (PatternDescr) lhs.getDescrs().get(2);
-        assertEquals(1,
-                     pattern.getConstraint().getDescrs().size());
+        assertThat(pattern.getConstraint().getDescrs().size()).isEqualTo(1);
 
         fieldAnd = (AndDescr) pattern.getConstraint();
         fld = (ExprConstraintDescr) fieldAnd.getDescrs().get(0);
@@ -782,34 +651,27 @@ public class MiscDRLParserTest extends TestCase {
     }
 
     @Test
-    public void testEmptyPattern() throws Exception {
+    void testEmptyPattern() throws Exception {
         String source = readResource("test_EmptyPattern.drl");
         PackageDescr pkg = parser.parse(source);
 
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
 
-        assertEquals(1,
-                     pkg.getRules().size());
+        assertThat(pkg.getRules().size()).isEqualTo(1);
         final RuleDescr ruleDescr = (RuleDescr) pkg.getRules().get(0);
-        assertEquals("simple rule",
-                     ruleDescr.getName());
-        assertNotNull(ruleDescr.getLhs());
-        assertEquals(1,
-                     ruleDescr.getLhs().getDescrs().size());
+        assertThat(ruleDescr.getName()).isEqualTo("simple rule");
+        assertThat(ruleDescr.getLhs()).isNotNull();
+        assertThat(ruleDescr.getLhs().getDescrs().size()).isEqualTo(1);
         final PatternDescr patternDescr = (PatternDescr) ruleDescr.getLhs().getDescrs().get(0);
-        assertEquals(0,
-                     patternDescr.getConstraint().getDescrs().size()); // this
-        assertEquals("Cheese",
-                     patternDescr.getObjectType());
+        assertThat(patternDescr.getConstraint().getDescrs().size()).isEqualTo(0); // this
+        assertThat(patternDescr.getObjectType()).isEqualTo("Cheese");
     }
 
     @Test
-    public void testSimpleMethodCallWithFrom() throws Exception {
+    void testSimpleMethodCallWithFrom() throws Exception {
         String source = readResource("test_SimpleMethodCallWithFrom.drl");
         PackageDescr pkg = parser.parse(source);
-        assertFalse(parser.getErrors().toString(),
-                    parser.hasErrors());
+        assertThat(parser.hasErrors()).as(parser.getErrors().toString()).isFalse();
         RuleDescr rule = (RuleDescr) pkg.getRules().get(0);
         final PatternDescr pattern = (PatternDescr) rule.getLhs().getDescrs().get(0);
         final FromDescr from = (FromDescr) pattern.getSource();

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,16 @@
   <properties>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
-    <version.drools-drl-ast>8.29.0.Final</version.drools-drl-ast>
+    <version.drools-drl-ast>8.31.0.Final</version.drools-drl-ast>
     <version.org.antlr4>4.9.3</version.org.antlr4>
     <version.org.eclipse.lsp4j>0.12.0</version.org.eclipse.lsp4j>
     <version.antlr4-c3>1.1</version.antlr4-c3>
-    <version.junit>4.13.2</version.junit>
-    <version.org.assertj>3.20.2</version.org.assertj>
+    <version.org.junit>5.9.1</version.org.junit>
+    <version.org.assertj>3.23.1</version.org.assertj>
     <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
+    <rewrite.maven.plugin.version>4.25.3</rewrite.maven.plugin.version>
+    <rewrite.testing.frameworks.version>1.22.0</rewrite.testing.frameworks.version>
+    <version.surefire.plugin>2.22.1</version.surefire.plugin>
   </properties>
 
   <modules>
@@ -26,4 +29,36 @@
     <module>drools-parser</module>
     <module>drools-completion</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite-maven-plugin</artifactId>
+        <version>${rewrite.maven.plugin.version}</version>
+        <configuration>
+          <activeRecipes>
+            <recipe>org.openrewrite.java.testing.junit5.JUnit4to5Migration</recipe>
+            <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
+            <recipe>org.openrewrite.java.testing.assertj.JUnitToAssertj</recipe>
+            <recipe>org.openrewrite.java.testing.junit5.StaticImports</recipe>
+            <recipe>org.openrewrite.java.testing.assertj.Assertj</recipe>
+          </activeRecipes>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-testing-frameworks</artifactId>
+            <version>${rewrite.testing.frameworks.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
OpenRewrite is applied for junit5 and assertj to be aligned with Drools code base direction.

There are some more room to improve (e.g. Remove `test` from test method names. Use `hasSize()` instead of `.size()` and  `isEqualTo()` etc.) , but I leave them for future PRs.